### PR TITLE
Modify `yai` and `newtargets` to accept reduced CCA axes (GNN)

### DIFF
--- a/R/newtargets.R
+++ b/R/newtargets.R
@@ -27,7 +27,7 @@
 #   ann: use ann or not...if null, the value is taken from object.
 #
 
-newtargets=function(object,newdata,k=NULL,ann=NULL)
+newtargets=function(object,newdata,k=NULL,ann=NULL,nVec=NULL)
 {
    if(!inherits(object, "yai")) stop ("object must be class yai")
    if (object$method == "ensemble") 
@@ -112,15 +112,20 @@ newtargets=function(object,newdata,k=NULL,ann=NULL)
    if (nrow(xTrgs)==0) stop("no observations")
    if (object$method == "gnn") # gnn
    {
+      # Reduce the number of axes if requested
+      if (is.null(nVec))
+         nVec=object$ccaVegan$CCA$rank
+      nVec=min(nVec,object$ccaVegan$CCA$rank)
+      nVec=max(nVec,1)
+
       # create a projected space for the reference observations
-      xcvRefs=predict(object$ccaVegan,type="lc",rank="full")
-      xcvRefs=xcvRefs %*% diag(sqrt(object$ccaVegan$CCA$eig/sum(object$ccaVegan$CCA$eig)))
+      xcvRefs=predict(object$ccaVegan,type="lc",rank=nVec)
+      xcvRefs=xcvRefs %*% diag(sqrt(object$ccaVegan$CCA$eig/sum(object$ccaVegan$CCA$eig))[1:nVec])
 
       # create a projected space for the unknowns (target observations)
       xcvTrgs=scale(xTrgs,center=object$xScale$center,scale=object$xScale$scale)
-      xcvTrgs=predict(object$ccaVegan,newdata=as.data.frame(xcvTrgs),type="lc",rank="full")
-      xcvTrgs=xcvTrgs %*% diag(sqrt(object$ccaVegan$CCA$eig/sum(object$ccaVegan$CCA$eig)))
-      nVec = ncol(xcvRefs)
+      xcvTrgs=predict(object$ccaVegan,newdata=as.data.frame(xcvTrgs),type="lc",rank=nVec)
+      xcvTrgs=xcvTrgs %*% diag(sqrt(object$ccaVegan$CCA$eig/sum(object$ccaVegan$CCA$eig))[1:nVec])
    }
    else if (object$method == "randomForest") # randomForest
    {

--- a/R/yai.R
+++ b/R/yai.R
@@ -547,9 +547,15 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
         ccaVegan = rda(X=yRefs, Y=xcvRefs)
       }
 
+      # reduce the number of axes if requested
+      if (is.null(nVec))
+         nVec=ccaVegan$CCA$rank
+      nVec=min(nVec,ccaVegan$CCA$rank)
+      nVec=max(nVec,1)
+
       # create a projected space for the reference observations
-      xcvRefs=predict(ccaVegan,type="lc",rank="full")
-      xcvRefs=xcvRefs %*% diag(sqrt(ccaVegan$CCA$eig/sum(ccaVegan$CCA$eig)))
+      xcvRefs=predict(ccaVegan,type="lc",rank=nVec)
+      xcvRefs=xcvRefs %*% diag(sqrt(ccaVegan$CCA$eig/sum(ccaVegan$CCA$eig))[1:nVec])
 
       # create a projected space for the unknowns (target observations)
       if (!noTrgs && length(trgs) > 0)
@@ -557,10 +563,9 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
          xTrgs=xall[trgs,,drop=FALSE]
          xcvTrgs=scale(xTrgs,center=xScale$center,scale=xScale$scale)
          xcvTrgs=predict(ccaVegan,
-                 newdata=as.data.frame(xcvTrgs),type="lc",rank="full")
-         xcvTrgs=xcvTrgs %*% diag(sqrt(ccaVegan$CCA$eig/sum(ccaVegan$CCA$eig)))
+                 newdata=as.data.frame(xcvTrgs),type="lc",rank=nVec)
+         xcvTrgs=xcvTrgs %*% diag(sqrt(ccaVegan$CCA$eig/sum(ccaVegan$CCA$eig))[1:nVec])
       }
-      nVec = ncol(xcvRefs)
    }
    else if (method == "randomForest")
    {  


### PR DESCRIPTION
Hi @jeffreyevans @nickcrookston - this PR is meant to accept a user-supplied `nVec` argument to optionally reduce the number of CCA axes used in the "gnn" method.  I'm horrible at R, but I used `yaImpute` for consistency when comparing against [our latest](https://github.com/lemma-osu/scikit-learn-knn-regression) `scikit-learn` based python code.  I found that I had to modify `yai` and `newtargets` to be able to reduce the number of CCA axes (from full rank), but please correct me if I'm wrong.  Please also feel free to ask to modify this code.  There is duplication of code between `yai` and `newtargets`, but that is to avoid modifying the `ccaVegan` object.  I also may not have modified all the locations where this would need to be done - for my comparisons, I only needed to modify in the two locations.

My main reason for adding this is that I feel like "gnn" is being overfit when using all CCA axes.  As far as I can tell, yaImpute uses all CCA axes in prediction, even though later axes typically have very little explanatory power.  We have always truncated GNN output to eight or fewer CCA axes.  This would make "gnn" more similar to "msn" in that "msn" uses `ftest.cor` to set a reasonable number of meaningful axes.  Note that we don't have a similar test for GNN for automatic reduction of axes. 
  
- use `nVec` in `yai` as a user-supplied argument to optionally reduce the number of CCA axes used for imputation
- add `nVec` keyword and apply the same logic in `newtargets`