### PR TITLE
Keep OOB observations in RF models

### DIFF
--- a/R/yai.R
+++ b/R/yai.R
@@ -578,7 +578,7 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
          mt = if (is.null(mtry)) max(floor(sqrt(ncol(xRefs))),1) else 
                                  min(mtry, ncol(xRefs))
          ranForest=randomForest(x=xRefs,y=yone,proximity=FALSE,importance=TRUE,
-                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE)
+                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE, predict.all = TRUE)
          ranForest$type="yaImputeUnsupervised"
          ranForest=list(unsupervised=ranForest)
       }
@@ -624,7 +624,7 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
                                     min(mtry, length(xN))
             ranForest[[i]]=randomForest(x=xRefs[,xN,FALSE],
               y=yone,proximity=FALSE,importance=TRUE,keep.forest=TRUE,
-              mtry=mt,ntree=ntree[i], keep.inbag = TRUE)
+              mtry=mt,ntree=ntree[i], keep.inbag = TRUE, predict.all = TRUE)
          }
          names(ranForest)=colnames(yRefs)
       }

--- a/R/yai.R
+++ b/R/yai.R
@@ -1,7 +1,7 @@
 yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
                 nVec=NULL,pVal=.05,method="msn",ann=TRUE,mtry=NULL,ntree=500,
                 rfMode="buildClasses",bootstrap=FALSE,ppControl=NULL,
-                sampleVars=NULL,rfXsubsets=NULL)
+                sampleVars=NULL,rfXsubsets=NULL,oob=FALSE)
 {
    # define functions used internally.
    sumSqDiff=function(x,y) { d=x-y; sum(d*d) }
@@ -582,8 +582,10 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
          yone=NULL
          mt = if (is.null(mtry)) max(floor(sqrt(ncol(xRefs))),1) else 
                                  min(mtry, ncol(xRefs))
-         ranForest=randomForest(x=xRefs,y=yone,proximity=FALSE,importance=TRUE,
-                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE)
+        predictall = if(oob) TRUE else FALSE
+        ranForest=randomForest(x=xRefs,y=yone,proximity=FALSE,importance=TRUE,
+                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE, 
+								predict.all = predictall)
          ranForest$type="yaImputeUnsupervised"
          ranForest=list(unsupervised=ranForest)
       }
@@ -627,9 +629,11 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
             }
             mt = if (is.null(mtry)) max(floor(sqrt(length(xN))), 1) else 
                                     min(mtry, length(xN))
+			predictall = if(oob) TRUE else FALSE
             ranForest[[i]]=randomForest(x=xRefs[,xN,FALSE],
               y=yone,proximity=FALSE,importance=TRUE,keep.forest=TRUE,
-              mtry=mt,ntree=ntree[i], keep.inbag = TRUE)
+              mtry=mt,ntree=ntree[i], keep.inbag = TRUE, 
+			  predict.all = predictall)
          }
          names(ranForest)=colnames(yRefs)
       }

--- a/R/yai.R
+++ b/R/yai.R
@@ -578,7 +578,7 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
          mt = if (is.null(mtry)) max(floor(sqrt(ncol(xRefs))),1) else 
                                  min(mtry, ncol(xRefs))
          ranForest=randomForest(x=xRefs,y=yone,proximity=FALSE,importance=TRUE,
-                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE, predict.all = TRUE)
+                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE)
          ranForest$type="yaImputeUnsupervised"
          ranForest=list(unsupervised=ranForest)
       }
@@ -624,7 +624,7 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
                                     min(mtry, length(xN))
             ranForest[[i]]=randomForest(x=xRefs[,xN,FALSE],
               y=yone,proximity=FALSE,importance=TRUE,keep.forest=TRUE,
-              mtry=mt,ntree=ntree[i], keep.inbag = TRUE, predict.all = TRUE)
+              mtry=mt,ntree=ntree[i], keep.inbag = TRUE)
          }
          names(ranForest)=colnames(yRefs)
       }

--- a/R/yai.R
+++ b/R/yai.R
@@ -578,7 +578,7 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
          mt = if (is.null(mtry)) max(floor(sqrt(ncol(xRefs))),1) else 
                                  min(mtry, ncol(xRefs))
          ranForest=randomForest(x=xRefs,y=yone,proximity=FALSE,importance=TRUE,
-                                keep.forest=TRUE,mtry=mt,ntree=ntree)
+                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE)
          ranForest$type="yaImputeUnsupervised"
          ranForest=list(unsupervised=ranForest)
       }
@@ -624,7 +624,7 @@ yai <- function(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
                                     min(mtry, length(xN))
             ranForest[[i]]=randomForest(x=xRefs[,xN,FALSE],
               y=yone,proximity=FALSE,importance=TRUE,keep.forest=TRUE,
-              mtry=mt,ntree=ntree[i])
+              mtry=mt,ntree=ntree[i], keep.inbag = TRUE)
          }
          names(ranForest)=colnames(yRefs)
       }

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# yaImpute (CRAN 1.0-32, dev 1.0-33) 
-<!-- badges: start -->
-[![CRAN
-status](http://www.r-pkg.org/badges/version/yaImpute)](https://cran.r-project.org/package=yaImpute)
-[![CRAN RStudio mirror
-downloads](http://cranlogs.r-pkg.org/badges/grand-total/yaImpute)](https://cran.r-project.org/package=yaImpute)
-<!-- badges: end -->
+# lleather/yaImpute - a fork
+
+I've updated the yai.R script to retain the OOB observations in random forest models. 
 
 # yaImpute (1.0-32) <img src="man/figures/logo.png" align="right" height="132" />
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 I've updated the yai.R script to retain the OOB observations in random forest models. 
 
+This is a simple addition-- in the yai.R script, I simply added the parameter "in.bag = TRUE" to the default Random Forests Call. 
+
+E.g.: 
+
+```
+ranForest=randomForest(x=xRefs,y=yone,proximity=FALSE,importance=TRUE,
+                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE)
+```
+
 # yaImpute (1.0-32) <img src="man/figures/logo.png" align="right" height="132" />
 
 yaImpute (Crookston & Finley 2007) Performs nearest neighbor-based imputation using one or more 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # lleather/yaImpute - a fork
 
-I've updated the yai.R script to retain the OOB observations in random forest models. 
+I've updated the yai.R script to retain the out-of-bag OOB observations in Random Forest models. 
 
-This is a simple addition-- in the yai.R script, I simply added the parameter "in.bag = TRUE" to the default Random Forests Call. 
+This is useful for calculating out-of-bag evaluation statistics for the RF models, which was not previously possible with outputs from the yaImpute package.
+
+This is a simple addition-- in the yai.R script, I simply added the parameter "in.bag = TRUE" to the default Random Forests call. 
 
 E.g.: 
 

--- a/man/yai.Rd
+++ b/man/yai.Rd
@@ -23,7 +23,7 @@
 yai(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
     nVec=NULL,pVal=.05,method="msn",ann=TRUE,mtry=NULL,ntree=500,
     rfMode="buildClasses",bootstrap=FALSE,ppControl=NULL,sampleVars=NULL,
-    rfXsubsets=NULL)
+    rfXsubsets=NULL,oob=FALSE)
 }
 
 \arguments{
@@ -96,7 +96,9 @@ yai(x=NULL,y=NULL,data=NULL,k=1,noTrgs=FALSE,noRefs=FALSE,
       variables to be included in the sample. Specification of a large number will cause the 
       sequence of variables to be randomized.}
   \item{rfXsubsets}{a named list of character vectors where there is one vector for each
-      Y-variable, see details, only applies when \code{method="randomForest"}}
+      Y-variable, see details, only applies when \code{method="randomForest"}}  
+  \item{oob}{Boolean when TRUE keep OOB in randomForest models, default FALSE. This is useful 
+      for calculating out-of-bag evaluation statistics for the models \code{method="randomForest"}}
 }
 
 \details{


### PR DESCRIPTION
I've updated the yai.R script to retain the out-of-bag (OOB) observations in Random Forest models.

This is useful for calculating out-of-bag evaluation statistics for the RF models, which was not previously possible with outputs from the yaImpute package.

This is a simple addition-- in the yai.R script, I simply added the parameter "in.bag = TRUE" to the default Random Forests call.

E.g.:

ranForest=randomForest(x=xRefs,y=yone,proximity=FALSE,importance=TRUE,
                                keep.forest=TRUE,mtry=mt,ntree=ntree, keep.inbag=TRUE)

I included the description above in the README for additional context; feel free to discard my additions to the README in the published version!